### PR TITLE
Remove the duplicated gem definition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ group :development, :test do
   gem 'pry-rails'
   gem 'hirb'
   gem 'hirb-unicode' # => HirbのUnicode対応版。日本語が入っていても結果がずれないようになります。
-  gem 'pry-rails'
 end
 
 group :test do


### PR DESCRIPTION
suppress a bundler warning like below:

> Your Gemfile lists the gem pry-rails (>= 0) more than once.
> You should probably keep only one of them.
> While it's not a problem now, it could cause errors if you change the version of just one of them later.